### PR TITLE
完善措辞和表述，明确使用var定义变量

### DIFF
--- a/2.2.md
+++ b/2.2.md
@@ -295,7 +295,7 @@ Go之所以会那么简洁，是因为它有一些默认的行为：
 	var ar = [10]byte {'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'}
 
 	// 声明两个含有byte的slice
-	var a,b[]byte
+	var a, b []byte
 
 	// a指向数组的第3个元素开始，并到第五个元素结束，
 	a = ar[2:5]
@@ -405,9 +405,9 @@ slice有一些简便的操作
 
 上面说过了，`map`也是一种引用类型，如果两个`map`同时指向一个底层，那么一个改变，另一个也相应的改变：
 
-	m = make(map[string]string)
+	m := make(map[string]string)
 	m["Hello"] = "Bonjour"
-	m1 = m
+	m1 := m
 	m1["Hello"] = "Salut"  // 现在m["hello"]的值已经是Salut了
 
 


### PR DESCRIPTION
Go定义变量分var关键字和简短方式，原句子中没有体现出使用var，同时变量、变量类型和变量名表述也不完整和清楚
