### PR TITLE
修正了最终生成的 html 文件中所有超链接仍指向 .md 后缀文件的问题。

### DIFF
--- a/build.go
+++ b/build.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"regexp"
 )
 
 // 定义一个访问者结构体
@@ -28,6 +29,7 @@ func (self *Visitor) visit(path string, f os.FileInfo, err error) error {
 				return err
 			}
 			input, _ := ioutil.ReadAll(file)
+			input = regexp.MustCompile("\\[(.*?)\\]\\(<?(.*?)\\.md>?\\)").ReplaceAll(input, []byte("[$1](<$2.html>)"))
 			output := blackfriday.MarkdownCommon(input)
 			var out *os.File
 			if out, err = os.Create(strings.Replace(f.Name(), ".md", ".html", -1)); err != nil {


### PR DESCRIPTION
之前生成的所有 html 文件里边，所有的超链接仍然指向 .md 文件，所以在使用 blackfriday 转换 Markdown 为 HTML 前，将其中的 .md 超链接替换成了 .html。 
