### PR TITLE
安装Go时可能还需要设置GOROOT环境变量

### DIFF
--- a/1.1.md
+++ b/1.1.md
@@ -82,6 +82,8 @@ Linux系统用户可通过在Terminal中执行命令`uname -a`来查看系统信
 
   解压缩`tar.gz`包到安装目录下：`tar zxvf go1.0.2.linux-amd64.tar.gz -C $GO_INSTALL_DIR`。
 
+  若安装目录非默认的 /usr/local/go (Windows下为 C:\go)，则需设置环境变量GOROOT: `export GOROOT=$GO_INSTALL_DIR/go`。
+
   设置PATH，`export PATH=$PATH:$GO_INSTALL_DIR/go/bin`
 
   然后执行`go`


### PR DESCRIPTION
如果go安装路径非默认路径，则执行go install命令时将得到如下错误：
    imports runtime: import "runtime": cannot find package
