### PR TITLE
Go-MySQL-Driver is now at GitHub

### DIFF
--- a/5.2.md
+++ b/5.2.md
@@ -4,7 +4,7 @@
 ## MySQL驱动
 Go中支持MySQL的驱动目前比较多，有如下几种，有些是支持database/sql标准，而有些是采用了自己的实现接口,常用的有如下几种:
 
-- http://code.google.com/p/go-mysql-driver/  支持database/sql，全部采用go写。
+- https://github.com/Go-SQL-Driver/MySQL  支持database/sql，全部采用go写。
 - https://github.com/ziutek/mymysql   支持database/sql，也支持自定义的接口，全部采用go写。
 - https://github.com/Philio/GoMySQL 不支持database/sql，自定义接口，全部采用go写。
 
@@ -37,7 +37,7 @@ Go中支持MySQL的驱动目前比较多，有如下几种，有些是支持data
 	package main
 
 	import (
-		_ "code.google.com/p/go-mysql-driver/mysql"
+		_ "github.com/Go-SQL-Driver/MySQL"
 		"database/sql"
 		"fmt"
 		//"time"
@@ -114,10 +114,10 @@ Go中支持MySQL的驱动目前比较多，有如下几种，有些是支持data
 
 关键的几个函数我解释一下：
 
-sql.Open()函数用来打开一个注册过的数据库驱动，go-mysql-driver中注册了mysql这个数据库驱动，第二个参数是DNS(Data Source Name)，它是go-mysql-drivev定义的一些数据库链接和配置信息。它支持如下格式：
+sql.Open()函数用来打开一个注册过的数据库驱动，Go-MySQL-Driver中注册了mysql这个数据库驱动，第二个参数是DNS(Data Source Name)，它是Go-MySQL-Driver定义的一些数据库链接和配置信息。它支持如下格式：
 
 	user@unix(/path/to/socket)/dbname?charset=utf8
-	user:password@tcp(localhost:5555)/dbname?charset=utf8&keepalive=1
+	user:password@tcp(localhost:5555)/dbname?charset=utf8
 	user:password@/dbname
 	user:password@tcp([de:ad:be:ef::ca:fe]:80)/dbname
 


### PR DESCRIPTION
Moreover `keepalive` is now deprecated, since closed connections can now be handled automatically (even more comfortable :wink:).
So please also change line 15. 
