### PR TITLE
使用更清晰的语句描述“控制TCP连接”一节

### DIFF
--- a/ebook/08.1.md
+++ b/ebook/08.1.md
@@ -233,13 +233,12 @@ TCP有很多连接控制函数，我们平常用到比较多的有如下几个�
 
 设置建立连接的超时时间，客户端和服务器端都适用，当超过设置时间时，连接自动关闭。
 
-  func (c *TCPConn) SetReadDeadline(t time.Time) error
-  
-  func (c *TCPConn) SetWriteDeadline(t time.Time) error
+	func (c *TCPConn) SetReadDeadline(t time.Time) error
+	func (c *TCPConn) SetWriteDeadline(t time.Time) error
   
 用来设置写入/读取一个连接的超时时间。当超过设置时间时，连接自动关闭。
 
- 	func (c *TCPConn) SetKeepAlive(keepalive bool) os.Error
+	func (c *TCPConn) SetKeepAlive(keepalive bool) os.Error
 
 设置客户端是否和服务器端保持长连接，可以降低建立TCP连接时的握手开销，对于一些需要频繁交换数据的应用场景比较适用。
 


### PR DESCRIPTION
将已废弃的函数替换成新API。
