### PR TITLE
修正示例代码中当客户端已关闭TCP连接时，服务端未及时关闭连接的问题

### DIFF
--- a/ebook/08.1.md
+++ b/ebook/08.1.md
@@ -261,20 +261,12 @@ Go语言中通过net包中的`DialTCP`函数来建立一个TCP连接，并返回
 			read_len, err := conn.Read(request)
 
 			if err != nil {
-				if err != io.EOF { // ignore EOF since client might send nothing for the moment
-					fmt.Println(err)
-					break
-				}
-
-				neterr, ok := err.(net.Error)
-				if ok && neterr.Timeout() {
-					fmt.Println(neterr)
-					break
-				}
+				fmt.Println(err)
+				break
 			}
 
     		if read_len == 0 {
-      			continue
+    			break // connection already closed by client
     		} else if string(request) == "timestamp" {
     			daytime := strconv.FormatInt(time.Now().Unix(), 10)
     			conn.Write([]byte(daytime))


### PR DESCRIPTION
Sorry, 之前提交的示例代码在实际应用中发现该问题，已经修正。
