### PR TITLE
Mac OS Sublime setting

### DIFF
--- a/ebook/01.4.md
+++ b/ebook/01.4.md
@@ -149,6 +149,14 @@
 
   如果没有出现这样的提示，一般就是你的`$PATH`没有配置正确。你可以打开终端，输入gocode，是不是能够正确运行，如果不行就说明`$PATH`没有配置正确。
 
+  4. MacOS下已经设置了$GOROOT, $GOPATH, $GOBIN，还是没有自动提示怎么办。
+  
+  请在sublime中使用command + 9， 然后输入env检查$PATH, GOROOT, $GOPATH, $GOBIN等变量， 如果没有请采用下面的方法。
+  
+  首先建立下面的连接， 然后从Terminal中直接启动sublime
+  
+  ln -s /Applications/Sublime\ Text\ 2.app/Contents/SharedSupport/bin/subl /usr/local/bin/sublime
+
 
 ## Vim
 Vim是从vi发展出来的一个文本编辑器, 代码补全、编译及错误跳转等方便编程的功能特别丰富，在程序员中被广泛使用。


### PR DESCRIPTION
Even after setting $GOPATH, $GOBIN, $GOROOT, autocomplete can't work.  

Open Sublime from terminal directly.
