### PR TITLE
修正go-sql-driver/mysql地址

### DIFF
--- a/ebook/05.2.md
+++ b/ebook/05.2.md
@@ -4,7 +4,7 @@
 ## MySQL驱动
 Go中支持MySQL的驱动目前比较多，有如下几种，有些是支持database/sql标准，而有些是采用了自己的实现接口,常用的有如下几种:
 
-- https://github.com/Go-SQL-Driver/MySQL  支持database/sql，全部采用go写。
+- https://github.com/go-sql-driver/mysql  支持database/sql，全部采用go写。
 - https://github.com/ziutek/mymysql   支持database/sql，也支持自定义的接口，全部采用go写。
 - https://github.com/Philio/GoMySQL 不支持database/sql，自定义接口，全部采用go写。
 


### PR DESCRIPTION
使用go get github.com/Go-SQL-Driver/MySQL获取时会报错，检查后发现确切的地址应该全是小写的。
