### PR TITLE
login里漏掉了ParseForm

### DIFF
--- a/ebook/04.1.md
+++ b/ebook/04.1.md
@@ -45,6 +45,7 @@ http包里面有一个很简单的方式就可以获取，我们在前面web的�
 	}
 
 	func login(w http.ResponseWriter, r *http.Request) {
+		r.ParseForm()       //解析url传递的参数，对于POST则解析响应包的主体（request body）
 		fmt.Println("method:", r.Method) //获取请求的方法
 		if r.Method == "GET" {
 			t, _ := template.ParseFiles("login.gtpl")


### PR DESCRIPTION
login里漏掉了ParseForm，导致以下值为空

```
fmt.Println("username:", r.Form["username"])
fmt.Println("password:", r.Form["password"])
```
