### PR TITLE
操作系统名采用统一的首字母大写。

### DIFF
--- a/ebook/01.3.md
+++ b/ebook/01.3.md
@@ -33,7 +33,7 @@
 	array_windows.go
 	array_freebsd.go
 
-  `go build`的时候会选择性地编译以系统名结尾的文件（linux、darwin、windows、freebsd）。例如Linux系统下面编译只会选择array_linux.go文件，其它系统命名后缀文件全部忽略。
+  `go build`的时候会选择性地编译以系统名结尾的文件（Linux、Darwin、Windows、Freebsd）。例如Linux系统下面编译只会选择array_linux.go文件，其它系统命名后缀文件全部忽略。
 
 ## go clean
 


### PR DESCRIPTION
>  `go build`的时候会选择性地编译以系统名结尾的文件（linux、darwin、windows、freebsd）。例如Linux系统下面编译只会选择array_linux.go文件，其它系统命名后缀文件全部忽略。

这句话里两次说到Linux，一次大写，一次小写。
