### PR TITLE
对字典的读写采用更谨慎的措辞

### DIFF
--- a/ebook/02.2.md
+++ b/ebook/02.2.md
@@ -403,7 +403,7 @@ slice有一些简便的操作
 - `map`的长度是不固定的，也就是和`slice`一样，也是一种引用类型
 - 内置的`len`函数同样适用于`map`，返回`map`拥有的`key`的数量
 - `map`的值可以很方便的修改，通过`numbers["one"]=11`可以很容易的把key为`one`的字典值改为`11`
-- `map`和其他基本型别不同，它不是thread-safe，在多个go-routine存取时，必须使用mutex lock机制
+- 在多个go-routine存取`map`时，必须互斥地访问(例如使用mutex lock机制)
 
 `map`的初始化可以通过`key:val`的方式初始化值，同时`map`内置有判断是否存在`key`的方式
 


### PR DESCRIPTION
> `map`和其他基本型别不同，它不是thread-safe，

如果多个goroutine 去同时读写同一个整数变量的值，最终造成每次执行后整数变量的值都不同。那可以说整数类型不是 thread-safe 的么。

> 在多个go-routine存取时，必须使用mutex lock机制

互斥访问的机制不光有互斥锁一种，您的措辞可能会让初学者产生困惑。
