### PR TITLE
修改13.5中的blog范例的api，从而能在新版beego中正常运行

### DIFF
--- a/ebook/13.5.md
+++ b/ebook/13.5.md
@@ -66,7 +66,7 @@ ViewController:
 	}
 	
 	func (this *ViewController) Get() {
-		id, _ := strconv.Atoi(this.Ctx.Input.Params[":id"])
+		id, _ := strconv.Atoi(this.Ctx.Input.Params(":id"))
 		this.Data["Post"] = models.GetBlog(id)
 		this.Layout = "layout.tpl"
 		this.TplNames = "view.tpl"
@@ -100,7 +100,7 @@ EditController
 	}
 	
 	func (this *EditController) Get() {
-		id, _ := strconv.Atoi(this.Ctx.Input.Params[":id"])
+		id, _ := strconv.Atoi(this.Ctx.Input.Params(":id"))
 		this.Data["Post"] = models.GetBlog(id)
 		this.Layout = "layout.tpl"
 		this.TplNames = "new.tpl"
@@ -124,7 +124,7 @@ DeleteController
 	}
 	
 	func (this *DeleteController) Get() {
-		id, _ := strconv.Atoi(this.Ctx.Input.Params[":id"])
+		id, _ := strconv.Atoi(this.Ctx.Input.Params(":id"))
 		blog := GetBlog(id int)
 		this.Data["Post"] = blog
 		models.DelBlog(blog)


### PR DESCRIPTION
主要修改了以下几点
1. beego.RegisterController 这个改为现在用的 beego.Router
2.删去了 Controller 中没有用到的变量
3. 修复了DeleteController 代码中调用API错误的一个bug
4. this.Ctx.Params[":id"] 接口已经改为this.Ctx.Input.Params(":id")
