### PR TITLE
fix issue with the missing images of the epub

### DIFF
--- a/ebook/build.go
+++ b/ebook/build.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"fmt"
-	"github.com/fairlyblank/md2min"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/fairlyblank/md2min"
 )
 
 // 定义一个访问者结构体
@@ -50,6 +51,9 @@ func (self *Visitor) md2html(arg map[string]string) error {
 		// 删除页面链接
 		input = RemoveFooterLink(input)
 
+		// remove image suffix
+		input = RemoveImageLinkSuffix(input)
+
 		var out *os.File
 		filename := strings.Replace(f.Name(), ".md", ".html", -1)
 		fmt.Println(to + "/" + filename)
@@ -83,6 +87,11 @@ func FixHeader(input string) string {
 func RemoveFooterLink(input string) string {
 	re_footer := regexp.MustCompile(`(?m)^#{2,} links.*?\n(.+\n)*`)
 	return re_footer.ReplaceAllString(input, "")
+}
+
+func RemoveImageLinkSuffix(input string) string {
+	re_footer := regexp.MustCompile(`png\?raw=true`)
+	return re_footer.ReplaceAllString(input, "png")
 }
 
 func main() {


### PR DESCRIPTION
modify the build.go so that the image paths are changed from
images/navi4.png?raw=true
to
images/navi4.png
when building the epub
