### PR TITLE
Update code sample for Go 1+

### DIFF
--- a/en/06.1.md
+++ b/en/06.1.md
@@ -60,8 +60,7 @@ Go uses the `SetCookie` function in the `net/http` package to set cookies:
 
 Here is an example of setting a cookie:
 
-	expiration := *time.LocalTime()
-	expiration.Year += 1
+	expiration := time.Now().Add(365 * 24 * time.Hour)
 	cookie := http.Cookie{Name: "username", Value: "astaxie", Expires: expiration}
 	http.SetCookie(w, &cookie)
 　　


### PR DESCRIPTION
`time.LocalTime()` no longer exists. I've updated that line to the current syntax.
