### PR TITLE
Update 13.2md

### DIFF
--- a/zh/13.2.md
+++ b/zh/13.2.md
@@ -14,7 +14,7 @@ HTTP路由组件负责将HTTP请求交到对应的函数处理(或者是一个st
 		fmt.Fprintf(w, "Hello, %q", html.EscapeString(r.URL.Path))
 	}
 
-	http.Handle("/foo", fooHandler)
+	http.HandleFunc("/foo", fooHandler)
 
 	http.HandleFunc("/bar", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "Hello, %q", html.EscapeString(r.URL.Path))


### PR DESCRIPTION
Should use http.HandleFunc if the second argument is a function.