### PR TITLE
Fixed example.

### DIFF
--- a/en/11.1.md
+++ b/en/11.1.md
@@ -82,7 +82,7 @@ The error's `Offset` field will not be printed at runtime when syntax errors occ
 
 It should be noted that when the function returns a custom error, the return value is set to the recommend type of error rather than a custom error type. Be careful not to pre-declare variables of custom error types. For example:
 
-    func Decode() *SyntaxError {
+    func Decode() error {
         // error, which may lead to the caller's err != nil comparison to always be true.
         var err * SyntaxError // pre-declare error variable
         if an error condition {


### PR DESCRIPTION
When the Decode()'s return type is *SyntaxError, err may actually be null. It is when the return type is an interface (ie error), that err (a nil *SyntaxError), now as an interface type, will never be nil (as explained in http://golang.org/doc/faq#nil_error).