### PR TITLE
Remove trailing whitespaces in en/13.5.md

### DIFF
--- a/en/13.5.md
+++ b/en/13.5.md
@@ -22,7 +22,7 @@ Our blog's directory structure can be seen below:
 	/delete.go
 	/edit.go	
 ```
-		
+
 
 ## Blog routing
 
@@ -73,7 +73,6 @@ func (this *IndexController) Get() {
 ```
 
 
-	
 ViewController:
 
 ```
@@ -112,9 +111,9 @@ func (this *NewController) Post() {
 	blog.Created = time.Now()
 	models.SaveBlog(blog)
 	this.Ctx.Redirect(302, "/")
-}	
-```	
-	
+}
+```
+
 
 EditController
 
@@ -142,7 +141,7 @@ func (this *EditController) Post() {
 	this.Ctx.Redirect(302, "/")
 }
 ```
-	
+
 DeleteController
 
 ```
@@ -155,7 +154,7 @@ func (this *DeleteController) Get() {
 	this.Data["Post"] = models.DelBlog(id)
 	this.Ctx.Redirect(302, "/")
 }
-```	
+```
 
 ## Model layer
 
@@ -237,7 +236,7 @@ layout.tpl
 </body>
 </html>
 ```
-	
+
 index.tpl
 
 ```
@@ -262,7 +261,7 @@ view.tpl
 {{.Post.Created}}<br/>
 
 {{.Post.Content}}
-```				
+```
 
 new.tpl
 
@@ -276,7 +275,7 @@ Content<textarea name="content" colspan="3" rowspan="10"></textarea>
 ```
 
 edit.tpl
-	
+
 ```
 <h1>Edit {{.Post.Title}}</h1>
 


### PR DESCRIPTION
This is to prevent the following `gitbook build` error
with GitBook 2.0.1:

    Template render error: unexpected token: .
        (In file '13.5.md', Line 281, Column 10)