### PR TITLE
Update on Int type example

### DIFF
--- a/en/02.2.md
+++ b/en/02.2.md
@@ -103,7 +103,7 @@ One important thing you should know that you cannot assign values between these 
 
 	c := a + b
 
-Although int has a longer length than uint8, and has the same length as int32, you cannot assign values between them. ( ***c will be asserted as type `int` here*** )
+Although int32 has a longer length than int8, and has the same type as int, you cannot assign values between them. ( ***c will be asserted as type `int` here*** )
 
 Float types have the `float32` and `float64` types and no type called `float`. The latter one is the default type if using brief statement.
 


### PR DESCRIPTION
Although int32 has a longer length than int8, and has the same type as int