### PR TITLE
Update recommended version and dl site

### DIFF
--- a/en/01.1.md
+++ b/en/01.1.md
@@ -26,11 +26,9 @@ On Unix-like systems, you need to install gcc or a similar compiler. For example
 
 On Windows, you need to install MinGW in order to install gcc. Don't forget to configure your environment variables after the installation has completed.( ***Everything that looks like this means it's commented by a translator: If you are using 64-bit Windows, you should install the 64-bit version of MinGW*** )
 
-The Go team uses [Mercurial](http://mercurial.selenic.com/downloads/) to manage their source code, so you need to install this tool in order to download the Go source code.
-
 At this point, execute the following commands to clone the Go source code and compile it.( ***It will clone the source code to your current directory. Switch your work path before you continue. This may take some time.*** )
 
-	hg clone -u release https://code.google.com/p/go
+	git clone https://go.googlesource.com/go
 	cd go/src
 	./all.bash 
 	
@@ -77,15 +75,15 @@ A 64-bit operating system will show the following:
 
 ### Mac
 
-Go to the [download page](http://code.google.com/p/go/downloads/list), choose `go1.0.3.darwin-386.pkg` for 32-bit systems and `go1.0.3.darwin-amd64.pkg` for 64-bit systems. Going all the way to the end by clicking "next", `~/go/bin` will be added to your system's $PATH after you finish the installation. Now open the terminal and type `go`. You should see the same output shown in igure 1.1.
+Go to the [download page](https://golang.org/dl/), choose `go1.4.2.darwin-386.pkg` for 32-bit systems and `go1.4.2.darwin-amd64.pkg` for 64-bit systems. Going all the way to the end by clicking "next", `~/go/bin` will be added to your system's $PATH after you finish the installation. Now open the terminal and type `go`. You should see the same output shown in igure 1.1.
 
 ### Linux
 
-Go to the [download page]((http://code.google.com/p/go/downloads/list), choose `go1.0.3.linux-386.tar.gz` for 32-bit systems and `go1.0.3.linux-amd64.tar.gz` for 64-bit systems. Suppose you want to install Go in the `$GO_INSTALL_DIR` path. Uncompress the `tar.gz` to your chosen path using the command `tar zxvf go1.0.3.linux-amd64.tar.gz -C $GO_INSTALL_DIR`. Then set your $PATH with the following: `export PATH=$PATH:$GO_INSTALL_DIR/go/bin`. Now just open the terminal and type `go`. You should now see the same output displayed in figure 1.1.
+Go to the [download page](https://golang.org/dl/), choose `go1.4.2.linux-386.tar.gz` for 32-bit systems and `go1.4.2.linux-amd64.tar.gz` for 64-bit systems. Suppose you want to install Go in the `$GO_INSTALL_DIR` path. Uncompress the `tar.gz` to your chosen path using the command `tar zxvf go1.4.2.linux-amd64.tar.gz -C $GO_INSTALL_DIR`. Then set your $PATH with the following: `export PATH=$PATH:$GO_INSTALL_DIR/go/bin`. Now just open the terminal and type `go`. You should now see the same output displayed in figure 1.1.
 
 ### Windows
 
-Go to the [download page]((http://code.google.com/p/go/downloads/list), choose `go1.0.3.windows-386.msi` for 32-bit systems and `go1.0.3.windows-amd64.msi` for 64-bit systems. Going all the way to the end by clicking "next", `c:/go/bin` will be added to `path`. Now just open a command line window and type `go`. You should now see the same output displayed in figure 1.1.
+Go to the [download page](https://golang.org/dl/), choose `go1.4.2.windows-386.msi` for 32-bit systems and `go1.4.2.windows-amd64.msi` for 64-bit systems. Going all the way to the end by clicking "next", `c:/go/bin` will be added to `path`. Now just open a command line window and type `go`. You should now see the same output displayed in figure 1.1.
 
 ## Use third-party tools
 
@@ -97,8 +95,8 @@ GVM is a Go multi-version control tool developed by a third-party, like rvm for 
 
 Then we install Go using the following commands:
 
-    gvm install go1.0.3
-    gvm use go1.0.3
+    gvm install go1.4.2
+    gvm use go1.4.2
 
 After the process has finished, you're all set.
 


### PR DESCRIPTION
Go team now uses git on gerrit. The current version is now also 1.4.2 and the place to download that is from golang.org