### PR TITLE
fix LiteIDE menu item name

### DIFF
--- a/en/01.4.md
+++ b/en/01.4.md
@@ -60,7 +60,7 @@ LiteIDE features.
 - Compilation environment
 
 	Switch configuration in LiteIDE to suit your operating system.
-	In Windows and using the 64-bit version of Go, you should choose win64 as the configuration environment in the tool bar. Then, choose `opinion`, find `LiteEnv` in the left list and open file `win64.env` in the right list.
+	In Windows and using the 64-bit version of Go, you should choose win64 as the configuration environment in the tool bar. Then, choose `Options`, find `LiteEnv` in the left list and open file `win64.env` in the right list.
 	
 		GOROOT=c:\go
 		GOBIN=
@@ -73,7 +73,7 @@ LiteIDE features.
 	
 	Replace `GOROOT=c:\go` to your Go installation path, save it. If you have MinGW64, add `c:\MinGW64\bin` to your path environment variable for `cgo` support.
 	
-	In Linux and using the 64-bit version of Go, you should choose linux64 as the configuration environment in the tool bar. Then, choose `opinion`, find `LiteEnv` in the left list and open the `linux64.env` file in the right list.
+	In Linux and using the 64-bit version of Go, you should choose linux64 as the configuration environment in the tool bar. Then, choose `Options`, find `LiteEnv` in the left list and open the `linux64.env` file in the right list.
 	
 		GOROOT=$HOME/go
 		GOBIN=

--- a/es/01.4.md
+++ b/es/01.4.md
@@ -60,7 +60,7 @@ Características de LiteIDE
 - Entorno de compilación
 
 	Cambia la configuración en LiteIDE para que se ajuste a tu sistema operativo.
-	En Windows y usando al versión de 64-bits de Go, debes usar win64 cómo la configuración de entorno en la barra de herramientas. Luego escoge `opinion`, busca `LiteEnv` en la lista de la izquierda y abre el archivo `win64.env` en la lista de la derecha.
+	En Windows y usando al versión de 64-bits de Go, debes usar win64 cómo la configuración de entorno en la barra de herramientas. Luego escoge `Options`, busca `LiteEnv` en la lista de la izquierda y abre el archivo `win64.env` en la lista de la derecha.
 
 		GOROOT=c:\go
 		GOBIN=
@@ -73,7 +73,7 @@ Características de LiteIDE
 
 	Reemplaza `GOROOT=c:\go` con tu ruta de instalación de Go y guarda. Si tienes MinGW64, agrega `c:\MinGW64\bin` a la variable de entorno de tu path para soportar `cgo`.
 
-	En Linux y usando la versiónd de 64-bits de Go, debes escoger linux64 como la configuración de entorno en la barra de herramientas. Luego escoge `opinion`, busca `LiteEnv` en la lista de la izquierda y abre el archivo `linux64.env` en la lista de la derecha.
+	En Linux y usando la versiónd de 64-bits de Go, debes escoger linux64 como la configuración de entorno en la barra de herramientas. Luego escoge `Options`, busca `LiteEnv` en la lista de la izquierda y abre el archivo `linux64.env` en la lista de la derecha.
 
 		GOROOT=$HOME/go
 		GOBIN=

--- a/fr/01.4.md
+++ b/fr/01.4.md
@@ -63,7 +63,7 @@ Fonctionnalités de LiteIDE:
 
 	Changer de configuration de LiteIDE pour correspondre à votre système d'exploitation
   Dans Windows avec la version 64-bit de Go, vous devriez utiliser win64 comme configuration de votre environnement dans la barre d'outils.
-  Ensuite, choisissez `option`, puis `LiteEnv` dans la liste de gauche et sélectionnez le fichier `win64.env` dans la liste de droite.
+  Ensuite, choisissez `Options`, puis `LiteEnv` dans la liste de gauche et sélectionnez le fichier `win64.env` dans la liste de droite.
 	
 		GOROOT=c:\go
 		GOBIN=
@@ -77,7 +77,7 @@ Fonctionnalités de LiteIDE:
 	Modifiez `GOROOT=c:\go` par le chemin de votre installation Go, puis sauvegardez. Si vous avez MinGW64, ajoutez `c:\MinGW64\bin` au chemin de votre variable d'environnement pour le support de `cgo`.
 
   Pour Linux avec Go en version 64-bit, choisissez linux64 comme configuration de votre environnement dans la barre d'outils.
-  Ensuite, choisissez `opinion`, puis `LiteEnv` dans la liste de gauche et sélectionnez le fichier `linux64.env` dans la liste de droite.
+  Ensuite, choisissez `Options`, puis `LiteEnv` dans la liste de gauche et sélectionnez le fichier `linux64.env` dans la liste de droite.
 	
 		GOROOT=$HOME/go
 		GOBIN=

--- a/tr/01.4.md
+++ b/tr/01.4.md
@@ -60,7 +60,7 @@ LiteIDE özellikleri:
 - Derleme Ortamı
 
 	Ayarlamalarınızı işletim sisteminize uygun bir şekilde yapın.
-	Go'nun 64-bitlik versiyonunu windowsta koşturuyorsanız, araç çubugunda konfigürasyon ortamı olarak  win64 olarak ayarlayın.`option` menüsü altındaki `liteEnv` sekmesine tıklayın ve `win64.env` adlı dosyayı açın.
+	Go'nun 64-bitlik versiyonunu windowsta koşturuyorsanız, araç çubugunda konfigürasyon ortamı olarak  win64 olarak ayarlayın.`Options` menüsü altındaki `liteEnv` sekmesine tıklayın ve `win64.env` adlı dosyayı açın.
 	
 		GOROOT=c:\go
 		GOBIN=
@@ -73,7 +73,7 @@ LiteIDE özellikleri:
 	
 	`GOROOT=c:\go` satırını kendi Go kurulu dizininize ayarlayın ve kaydedin. MinGW64 kullanıyorsanız,`c:\MinGW64\bin`yi `cgo` desteği için PATH değişkenine ekleyin.
 	
-	Go'nun 64-bitlik linuxta koşturuyorsanız, araç çubuğunda kanfigürasyon ortamı olarak linux64 olarak ayarlayın. `option` menüsü altındaki `liteEnv` sekmesine tıklayın ve `linux64.env` adlı dosyayı açın.
+	Go'nun 64-bitlik linuxta koşturuyorsanız, araç çubuğunda kanfigürasyon ortamı olarak linux64 olarak ayarlayın. `Options` menüsü altındaki `liteEnv` sekmesine tıklayın ve `linux64.env` adlı dosyayı açın.
 	
 		GOROOT=$HOME/go
 		GOBIN=


### PR DESCRIPTION
Change the menu item to `Options` (not `opinion` or `options`).
It'll be less confusing for readers to follow.