### PR TITLE
Update 02.6.md: Fixed typo. Changed "have" to "behave".

### DIFF
--- a/en/02.6.md
+++ b/en/02.6.md
@@ -326,7 +326,7 @@ One thing you should remember is that `element.(type)` cannot be used outside of
 
 ### Embedded interfaces
 
-The most beautiful thing is that Go has a lot of built-in logic syntax, such as anonymous fields in struct. Not suprisingly, we can use interfaces as anonymous fields as well, but we call them `Embedded interfaces`. Here, we follow the same rules as anonymous fields. More specifically, if an interface has another interface embedded within it, it will have as if it has all the methods that the embedded interface has.
+The most beautiful thing is that Go has a lot of built-in logic syntax, such as anonymous fields in struct. Not suprisingly, we can use interfaces as anonymous fields as well, but we call them `Embedded interfaces`. Here, we follow the same rules as anonymous fields. More specifically, if an interface has another interface embedded within it, it will behave as if it has all the methods that the embedded interface has.
 
 We can see that the source file in `container/heap` has the following definition:
 


### PR DESCRIPTION
Fixed typo. Changed "have" to "behave".