### PR TITLE
5.3 SQLite fixed

### DIFF
--- a/de/05.3.md
+++ b/de/05.3.md
@@ -30,6 +30,7 @@ An example:
 	import (
 	    "database/sql"
 	    "fmt"
+	    "time"
 	    _ "github.com/mattn/go-sqlite3"
 	)
 	
@@ -68,7 +69,7 @@ An example:
 	        var uid int
 	        var username string
 	        var department string
-	        var created string
+	        var created time.Time
 	        err = rows.Scan(&uid, &username, &department, &created)
 	        checkErr(err)
 	        fmt.Println(uid)

--- a/en/05.3.md
+++ b/en/05.3.md
@@ -30,6 +30,7 @@ An example:
 	import (
 	    "database/sql"
 	    "fmt"
+	    "time"
 	    _ "github.com/mattn/go-sqlite3"
 	)
 	
@@ -68,7 +69,7 @@ An example:
 	        var uid int
 	        var username string
 	        var department string
-	        var created string
+	        var created time.Time
 	        err = rows.Scan(&uid, &username, &department, &created)
 	        checkErr(err)
 	        fmt.Println(uid)

--- a/ja/05.3.md
+++ b/ja/05.3.md
@@ -35,6 +35,7 @@ Goがサポートするsqliteのドライバも比較的多いのですが、大
 	import (
 		"database/sql"
 		"fmt"
+		"time"
 		_ "github.com/mattn/go-sqlite3"
 	)
 
@@ -73,7 +74,7 @@ Goがサポートするsqliteのドライバも比較的多いのですが、大
 			var uid int
 			var username string
 			var department string
-			var created string
+			var created time.Time
 			err = rows.Scan(&uid, &username, &department, &created)
 			checkErr(err)
 			fmt.Println(uid)

--- a/pt-br/05.3.md
+++ b/pt-br/05.3.md
@@ -30,6 +30,7 @@ An example:
 	import (
 	    "database/sql"
 	    "fmt"
+	    "time"
 	    _ "github.com/mattn/go-sqlite3"
 	)
 	
@@ -68,7 +69,7 @@ An example:
 	        var uid int
 	        var username string
 	        var department string
-	        var created string
+	        var created time.Time
 	        err = rows.Scan(&uid, &username, &department, &created)
 	        checkErr(err)
 	        fmt.Println(uid)

--- a/zh/05.3.md
+++ b/zh/05.3.md
@@ -35,6 +35,7 @@ Go支持sqlite的驱动也比较多，但是好多都是不支持database/sql接
 	import (
 		"database/sql"
 		"fmt"
+		"time"
 		_ "github.com/mattn/go-sqlite3"
 	)
 
@@ -73,7 +74,7 @@ Go支持sqlite的驱动也比较多，但是好多都是不支持database/sql接
 			var uid int
 			var username string
 			var department string
-			var created string
+			var created time.Time
 			err = rows.Scan(&uid, &username, &department, &created)
 			checkErr(err)
 			fmt.Println(uid)


### PR DESCRIPTION
__SQLite version 3.8.5__
__Go version 1.4.2 darwin/amd64__

The example in 5.3 is not working:
```
$ go run new.go
id: 1
affect: 1
panic: sql: Scan error on column index 3: unsupported driver -> Scan pair: time.Time -> *string

goroutine 1 [running]:
main.checkErr(0x4348740, 0xc20800a590)
	/Users/chenxiao.ma/Desktop/new/new.go:72 +0x50
main.main()
	/Users/chenxiao.ma/Desktop/new/new.go:47 +0xa9e

goroutine 5 [chan receive]:
database/sql.(*DB).connectionOpener(0xc208030000)
	/usr/local/go/src/database/sql/sql.go:589 +0x4c
created by database/sql.Open
	/usr/local/go/src/database/sql/sql.go:452 +0x31c

goroutine 17 [syscall, locked to thread]:
runtime.goexit()
	/usr/local/go/src/runtime/asm_amd64.s:2232 +0x1
exit status 2
```

This is because `database/sql` in Go doesn't have conversion between time and string.
The example can be compiled and run with `var created time.Time`.
Please refer to this issue:
https://github.com/mattn/go-sqlite3/issues/230