### PR TITLE
Changes on URLs from Golang are now updated with the current versions

### DIFF
--- a/es/01.1.md
+++ b/es/01.1.md
@@ -77,15 +77,15 @@ En cambio los sistemas operativos de 32-bits mostrarán:
 
 ### Mac
 
-Ve a la [página de descarga](http://code.google.com/p/go/downloads/list), escoge `go1.0.3.darwin-386.pkg` para sistemas de 32-bits y `go1.0.3.darwin-amd64.pkg` para sistemas de 64-bits. Ve hasta el final presionando "next",`~/go/bin` será agregado al $PATH de tu sistema al finalizar la instalación. Ahora abre la terminal y escribe `go`. Debes ver el mismo resultado que se muestra en la imagen 1.1.
+Ve a la [página de descarga](https://golang.org/dl/), escoge `go1.5.3.darwin-amd64.pkg` para sistemas de 64-bits. Ve hasta el final presionando "next",`~/go/bin` será agregado al $PATH de tu sistema al finalizar la instalación. Ahora abre la terminal y escribe `go`. Debes ver el mismo resultado que se muestra en la imagen 1.1.
 
 ### Linux
 
-Ve a la [página de descarga](http://code.google.com/p/go/downloads/list), escoge `go1.0.3.linux-386.tar.gz` para sistemas de 32-bits y `go1.0.3.linux-amd64.tar.gz` para sistemas de 64-bits. Supongamos que quieres instalar Go en la ruta `$GO_INSTALL_DIR`. Descomprime el archivo `tar.gz` a la ruta que escojas usando el comando `tar zxvf go1.0.3.linux-amd64.tar.gz -C $GO_INSTALL_DIR`. Luego configura tu $PATH con el siguiente comando: `export PATH=$PATH:$GO_INSTALL_DIR/go/bin`. Ahora abre la terminal y escribe `go`. Debes ver el mismo resultado que se muestra en la imagen 1.1.
+Ve a la [página de descarga](https://golang.org/dl/), escoge `go1.5.3.linux-386.tar.gz` para sistemas de 32-bits y `go1.5.3.linux-amd64.tar.gz` para sistemas de 64-bits. Supongamos que quieres instalar Go en la ruta `$GO_INSTALL_DIR`. Descomprime el archivo `tar.gz` a la ruta que escojas usando el comando `tar zxvf go1.0.3.linux-amd64.tar.gz -C $GO_INSTALL_DIR`. Luego configura tu $PATH con el siguiente comando: `export PATH=$PATH:$GO_INSTALL_DIR/go/bin`. Ahora abre la terminal y escribe `go`. Debes ver el mismo resultado que se muestra en la imagen 1.1.
 
 ### Windows
 
-Ve a la [página de descarga](http://code.google.com/p/go/downloads/list), escoge `go1.0.3.windows-386.msi` para sistemas de 32-bits y `go1.0.3.windows-amd64.msi` para sistemas de 64-bits. Ve hasta el final presionando "next", `c:/go/bin` será agregado al `path`. Ahora abre la terminal y escribe `go`. Debes ver el mismo resultado que se muestra en la imagen 1.1.
+Ve a la [página de descarga](https://golang.org/dl/), escoge `go1.5.3.windows-386.msi` para sistemas de 32-bits y `go1.5.3.windows-amd64.msi` para sistemas de 64-bits. Ve hasta el final presionando "next", `c:/go/bin` será agregado al `path`. Ahora abre la terminal y escribe `go`. Debes ver el mismo resultado que se muestra en la imagen 1.1.
 
 ## Usando herramientas de terceros
 


### PR DESCRIPTION
This changes are updating the URLs from the old page of Goland (from code.google.com) to the new golang.org site. Also, the versions in the book were older (1.0.3) while we just updated to the new one (1.5.3).