### PR TITLE
Added a check for empty request method in example - en

### DIFF
--- a/en/04.1.md
+++ b/en/04.1.md
@@ -45,7 +45,7 @@ This is easy to find out using the `http` package. Let's see how to handle the f
 
 	func login(w http.ResponseWriter, r *http.Request) {
 		fmt.Println("method:", r.Method) //get request method
-		if r.Method == "GET" {
+		if r.Method == "GET" || r.Method == "" {
 			t, _ := template.ParseFiles("login.gtpl")
 			t.Execute(w, nil)
 		} else {


### PR DESCRIPTION
the `r.Method` can be an empty string as well, see the comments in net/htt/request.go file under the definition of the `Request` struct.

I've included the changes only in the English translation, as that's what i've been following.