### PR TITLE
Remove Base64 encoding as 'encryption' algorithm

### DIFF
--- a/de/09.6.md
+++ b/de/09.6.md
@@ -2,44 +2,6 @@
 
 The previous section describes how to securely store passwords, but sometimes it might be neccessary to modify some sensitive encrypted data that has already been stored into our database. When data decryption is required, we should use a symmetric encryption algorithm instead of the one-way hashing techniques we've previously covered. 
 
-## Base64 Encryption and decryption
-
-If the web application is relatively simple, and the data security requirements are not so stringent, then you can use a relatively simple method of encryption and decryption using `base64`. This approach is relatively straightforward to implement, and Go's `base64` package has good support for this. Consider the following example:
-
-	package main
-	
-	import (
-		"encoding/base64"
-		"fmt"
-	)
-	
-	func base64Encode(src []byte) []byte {
-		return []byte(base64.StdEncoding.EncodeToString(src))
-	}
-	
-	func base64Decode(src []byte) ([]byte, error) {
-		return base64.StdEncoding.DecodeString(string(src))
-	}
-	
-	func main() {
-		// encode
-		hello := "你好，世界！ hello world"
-		debyte := base64Encode([]byte(hello))
-		fmt.Println(debyte)
-		// decode
-		enbyte, err := base64Decode(debyte)
-		if err != nil {
-			fmt.Println(err.Error())
-		}
-	
-		if hello != string(enbyte) {
-			fmt.Println("hello is not equal to enbyte")
-		}
-	
-		fmt.Println(string(enbyte))
-	}
-
-
 ## Advanced encryption and decryption
 
 The Go language supports symmetric encryption algorithms in its `crypto` package. Two advanced encryption modules are:
@@ -115,7 +77,7 @@ These three functions implement encryption and decryption operations; see the Go
 
 ## Summary
 
-This section describes several encryption algorithms which can be used in different ways according to your web application's encryption and decryption needs. For the most basic applications, base64 encoding may suffice. For applications with more stringent security requirements, it's recommended to use the more advanced AES or DES algorithm .
+This section describes encryption algorithms which can be used in different ways according to your web application's encryption and decryption needs. For applications with even basic security requirements it is recommended to use AES.
 
 
 ## Links

--- a/en/09.6.md
+++ b/en/09.6.md
@@ -2,44 +2,6 @@
 
 The previous section describes how to securely store passwords, but sometimes it might be neccessary to modify some sensitive encrypted data that has already been stored into our database. When data decryption is required, we should use a symmetric encryption algorithm instead of the one-way hashing techniques we've previously covered. 
 
-## Base64 Encryption and decryption
-
-If the web application is relatively simple, and the data security requirements are not so stringent, then you can use a relatively simple method of encryption and decryption using `base64`. This approach is relatively straightforward to implement, and Go's `base64` package has good support for this. Consider the following example:
-
-	package main
-	
-	import (
-		"encoding/base64"
-		"fmt"
-	)
-	
-	func base64Encode(src []byte) []byte {
-		return []byte(base64.StdEncoding.EncodeToString(src))
-	}
-	
-	func base64Decode(src []byte) ([]byte, error) {
-		return base64.StdEncoding.DecodeString(string(src))
-	}
-	
-	func main() {
-		// encode
-		hello := "你好，世界！ hello world"
-		debyte := base64Encode([]byte(hello))
-		fmt.Println(debyte)
-		// decode
-		enbyte, err := base64Decode(debyte)
-		if err != nil {
-			fmt.Println(err.Error())
-		}
-	
-		if hello != string(enbyte) {
-			fmt.Println("hello is not equal to enbyte")
-		}
-	
-		fmt.Println(string(enbyte))
-	}
-
-
 ## Advanced encryption and decryption
 
 The Go language supports symmetric encryption algorithms in its `crypto` package. Two advanced encryption modules are:
@@ -115,7 +77,7 @@ These three functions implement encryption and decryption operations; see the Go
 
 ## Summary
 
-This section describes several encryption algorithms which can be used in different ways according to your web application's encryption and decryption needs. For the most basic applications, base64 encoding may suffice. For applications with more stringent security requirements, it's recommended to use the more advanced AES or DES algorithm .
+This section describes encryption algorithms which can be used in different ways according to your web application's encryption and decryption needs. For applications with even basic security requirements it is recommended to use AES.
 
 
 ## Links


### PR DESCRIPTION
This statement is just simply wrong and even dangerous if people start to believe their application is secure, because they used Base64