### PR TITLE
Align folders in the mygo folder tree

### DIFF
--- a/zh/01.2.md
+++ b/zh/01.2.md
@@ -163,9 +163,9 @@ go get本质上可以理解为首先第一步是通过源码工具clone代码到
 	src/
 		mathapp
 			  main.go
-		  mymath/
+		mymath/
 			  sqrt.go
-		  github.com/
+		github.com/
 			   astaxie/
 					beedb/
 						beedb.go


### PR DESCRIPTION
Folders mathapp, mymath and github.com should directly appear in src folder, so mymath and github.com folders in the folder structure tree should be aligned to mathapp folder.

It confused me a bit.