### PR TITLE
Change the 'value' parameter description

### DIFF
--- a/zh/02.7.md
+++ b/zh/02.7.md
@@ -93,8 +93,7 @@ channel通过操作符`<-`来接收和发送数据
 
 	ch := make(chan type, value)
 
-	value == 0 ! 无缓冲（阻塞）
-	value > 0 ! 缓冲（非阻塞，直到value 个元素）
+当 value = 0 时，channel 是无缓冲阻塞读写的，当value > 0 时，channel 有缓冲、是非阻塞的，直到写满 value 个元素才阻塞写入。
 
 我们看一下下面这个例子，你可以在自己本机测试一下，修改相应的value值
 


### PR DESCRIPTION
I'd like to think the description of 'value' parameter isn't the part of the code. I was confused by it when it's written in the code block, then I realized it's the explanation of the parameter.