### PR TITLE
Add debug log for template execution

### DIFF
--- a/zh/04.1.md
+++ b/zh/04.1.md
@@ -48,7 +48,7 @@ http包里面有一个很简单的方式就可以获取，我们在前面web的�
 		fmt.Println("method:", r.Method) //获取请求的方法
 		if r.Method == "GET" {
 			t, _ := template.ParseFiles("login.gtpl")
-			t.Execute(w, nil)
+			log.Println(t.Execute(w, nil))
 		} else {
 			//请求的是登陆数据，那么执行登陆的逻辑判断
 			fmt.Println("username:", r.Form["username"])
@@ -73,6 +73,8 @@ login函数中我们根据`r.Method`来判断是显示登录界面还是处理�
 当我们在浏览器里面打开`http://127.0.0.1:9090/login`的时候，出现如下界面
 
 ![](images/4.1.login.png?raw=true)
+
+如果你看到一个空页面，可能是你写的 login.gtpl 文件中有错误，请根据控制台中的日志进行修复。
 
 图4.1 用户登录界面
 


### PR DESCRIPTION
In order to display errors such as wrong html syntax and bad html structure in "login.gtpl", I'd like to suggest to add log information to help people release errors in the template file. Currently if I'm trying to render a bad template file I'll see a blank page without any information.