### PR TITLE
Fix Index link in English README.

### DIFF
--- a/en/README.md
+++ b/en/README.md
@@ -38,4 +38,4 @@ the code is licensed under a [BSD 3-Clause License](<https://github.com/astaxie/
 
 ### Get Started
 
-[Index](./eBook/preface.md)
+[Index](./preface.md)


### PR DESCRIPTION
It was pointing into an `eBook` directory that no longer looks to exist.