### PR TITLE
.只能匹配任意字符一次

### DIFF
--- a/zh/09.2.md
+++ b/zh/09.2.md
@@ -59,7 +59,7 @@
 	r.ParseForm()
 	username := r.Form.Get("username")
 	CleanMap := make(map[string]interface{}, 0)
-	if ok, _ := regexp.MatchString("^[a-zA-Z0-9].$", username); ok {
+	if ok, _ := regexp.MatchString("^[a-zA-Z0-9]+$", username); ok {
 		CleanMap["username"] = username
 	}
 


### PR DESCRIPTION
要匹配由数字和字母组成的字符，需要使用"^[a-zA-Z0-9]+$"，"^[a-zA-Z0-9]+."只能匹配由数字字母开头和一个任意字符组成的两个长度的字符串。