### PR TITLE
替换 websocket 地址

### DIFF
--- a/zh/08.2.md
+++ b/zh/08.2.md
@@ -41,7 +41,7 @@ WebSocket的协议颇为简单，在第一次handshake通过以后，连接便�
 ## Go实现WebSocket
 Go语言标准包里面没有提供对WebSocket的支持，但是在由官方维护的go.net子包中有对这个的支持，你可以通过如下的命令获取该包：
 
-	go get code.google.com/p/go.net/websocket
+	go get golang.org/x/net/websocket
 
 WebSocket分为客户端和服务端，接下来我们将实现一个简单的例子:用户输入信息，客户端通过WebSocket将信息发送给服务器端，服务器端收到信息之后主动Push信息到客户端，然后客户端将输出其收到的信息，客户端的代码如下：
 


### PR DESCRIPTION
原地址code.google.com/p/go.net/websocket 不可以用了  修改为golang.org/x/net/websocket