### PR TITLE
Include new line before snippet

### DIFF
--- a/pt-br/01.2.md
+++ b/pt-br/01.2.md
@@ -55,6 +55,7 @@ Agora que nós criamos nosso pacote, como vamos utilizá-lo de modo prático? Ex
 2. Execute o comando acima, utilizando o nome do arquivo sem extenção, exemplo: `go install mymath`.
 
 Após compilado, podemos ver o arquivo executável do pacote na seguinte pasta:
+
 	cd $GOPATH/pkg/${GOOS}_${GOARCH}
 	// O arquivo do pacote gerado com a extenção .a
 	mymath.a


### PR DESCRIPTION
The absence of a new line was making the code snippet not render correctly in the markdown visualization.

A code snippet will only show it it's preceded and succeeded by empty lines.

This pull request includes a missing blank line.