### PR TITLE
Update 05.5.md

### DIFF
--- a/zh/05.5.md
+++ b/zh/05.5.md
@@ -41,13 +41,15 @@ import (
 )
 
 func init() {
-	// 设置默认数据库
+	//注册驱动
+	orm.RegisterDriver("mysql", orm.DR_MySQL)
+	//设置默认数据库
 	orm.RegisterDataBase("default", "mysql", "root:root@/my_db?charset=utf8", 30)
 	//注册定义的model
     	orm.RegisterModel(new(User))
 
-   	   // 创建table
-       orm.RunSyncdb("default", false, true)
+   	// 创建table
+        orm.RunSyncdb("default", false, true)
 }
 ```
 
@@ -97,7 +99,7 @@ beego orm:
 ```Go
 
 func main() {
-    	orm := orm.NewOrm()
+    	o := orm.NewOrm()
 }
 ```
 
@@ -406,8 +408,8 @@ Having:用来指定having执行的时候的条件
 
 ```Go
 
-o := NewOrm()
-var r RawSeter
+o := orm.NewOrm()
+var r orm.RawSeter
 r = o.Raw("UPDATE user SET name = ? WHERE name = ?", "testing", "slene")
 ```
 


### PR DESCRIPTION
1、init函数中mysql演示配置和下面不一致，容易引起误解
2、orm := orm.NewOrm()，命名冲突。报名和变量名冲突。
3、使用原生sql示例缺少包名orm,易引起误会