### PR TITLE
fix "needs a primary..." or "can not find..." ...

### DIFF
--- a/zh/05.5.md
+++ b/zh/05.5.md
@@ -183,15 +183,8 @@ orm.SetMaxOpenConns("default", 30)
 接下来我们的例子采用前面的数据库表User，现在我们建立相应的struct
 ```Go
 
-type Userinfo struct {
-	Uid     int `PK` //如果表的主键不是id，那么需要加上pk注释，显式的说这个字段是主键
-	Username    string
-	Departname  string
-	Created     time.Time
-}
-
 type User struct {
-	Uid          int `PK` //如果表的主键不是id，那么需要加上pk注释，显式的说这个字段是主键
+	Uid          int `orm:"pk"` //如果表的主键不是id，那么需要加上pk注释，显式的说这个字段是主键
 	Name        string
 	Profile     *Profile   `orm:"rel(one)"` // OneToOne relation
 	Post        []*Post `orm:"reverse(many)"` // 设置一对多的反向关系
@@ -218,7 +211,7 @@ type Tag struct {
 
 func init() {
 	// 需要在init中注册定义的model
-	orm.RegisterModel(new(Userinfo),new(User), new(Profile), new(Tag))
+	orm.RegisterModel(new(User), new(Profile), new(Tag), new(Post))
 }
 
 
@@ -232,7 +225,6 @@ func init() {
 o := orm.NewOrm()
 var user User
 user.Name = "zxxx"
-user.Departname = "zxxx"
 
 id, err := o.Insert(&user)
 if err == nil {


### PR DESCRIPTION
<orm.RegisterModel> `main.User` needs a primary key field, default is to use 'id' if not set
exit status 2

can not find rel in field `main.Tag.Posts`, `main.Post` may be miss register
exit status 2