### PR TITLE
update socket编程部分 readAll -> read

### DIFF
--- a/zh/08.1.md
+++ b/zh/08.1.md
@@ -151,7 +151,7 @@ func main() {
 	checkError(err)
 	// result, err := ioutil.ReadAll(conn)
 	result := make([]byte, 256)
-	_, err = conn.Read(result
+	_, err = conn.Read(result)
 	checkError(err)
 	fmt.Println(string(result))
 	os.Exit(0)

--- a/zh/08.1.md
+++ b/zh/08.1.md
@@ -149,7 +149,9 @@ func main() {
 	checkError(err)
 	_, err = conn.Write([]byte("HEAD / HTTP/1.0\r\n\r\n"))
 	checkError(err)
-	result, err := ioutil.ReadAll(conn)
+	// result, err := ioutil.ReadAll(conn)
+	result := make([]byte, 256)
+	_, err = conn.Read(result
 	checkError(err)
 	fmt.Println(string(result))
 	os.Exit(0)


### PR DESCRIPTION
go version go1.11.5 darwin/amd64
执行socket client/server示例报错，read: connection reset by peer
原因是readAll要一直读到EOF才结束，server端已断开连接