### PR TITLE
Fix command not monospaced.

### DIFF
--- a/en/01.3.md
+++ b/en/01.3.md
@@ -49,7 +49,7 @@ I usually use this command to clean up my files before I upload my project to Gi
 
 The people who are working with C/C++ should know that people are always arguing about which code style is better: K&R-style or ANSI-style. However in Go, there is only one code style which is enforced. For example, left braces must only be inserted at the end of lines, and they cannot be on their own lines, otherwise you will get compile errors! Fortunately, you don't have to remember these rules. `go fmt` does this job for you. Just execute the command `go fmt <File name>.go` in terminal. I don't use this command very much because IDEs usually execute this command automatically when you save source files. I will talk more about IDEs in the next section.
 
-`go fmt` is just an alias, which runs the command 'gofmt -l -w' on the packages named by the import paths.
+`go fmt` is just an alias, which runs the command `gofmt -l -w` on the packages named by the import paths.
 
 We usually use `gofmt -w` instead of `go fmt`. The latter will not rewrite your source files after formatting code. `gofmt -w src` formats the whole project.
 


### PR DESCRIPTION
Fix a typo that `gofmt -l -w` command is not monospaced.