### PR TITLE
Fix Markdown error in displaying in en/02.3 & 02.4

### DIFF
--- a/en/02.3.md
+++ b/en/02.3.md
@@ -501,8 +501,9 @@ There are some special operators when we import packages, and beginners are alwa
 import(
     . "fmt"
 )
-```		
-	The dot operator means you can omit the package name when you call functions inside of that package. Now `fmt.Printf("Hello world")` becomes to `Printf("Hello world")`.
+```
+
+The dot operator means you can omit the package name when you call functions inside of that package. Now `fmt.Printf("Hello world")` becomes to `Printf("Hello world")`.
 2. Alias operation.
 	It changes the name of the package that we imported when we call functions that belong to that package.
 ```Go
@@ -510,7 +511,7 @@ import(
 	f "fmt"
 )
 ```		
-	Now `fmt.Printf("Hello world")` becomes to `f.Printf("Hello world")`.
+Now `fmt.Printf("Hello world")` becomes to `f.Printf("Hello world")`.
 3. `_` operator.
 	This is the operator that is difficult to understand without someone explaining it to you.
 ```Go
@@ -519,7 +520,7 @@ import (
     _ "github.com/ziutek/mymysql/godrv"
 )
 ```
-	The `_` operator actually means we just want to import that package and execute its `init` function, and we are not sure if we want to use the functions belonging to that package.
+The `_` operator actually means we just want to import that package and execute its `init` function, and we are not sure if we want to use the functions belonging to that package.
 
 ## Links
 

--- a/en/02.4.md
+++ b/en/02.4.md
@@ -181,7 +181,7 @@ In the above example, we can see that all types can be embedded fields and we ca
 
 There is one more problem however. If Human has a field called `phone` and Student has a field with same name, what should we do?
 
-Go use a very simple way to solve it. The outer fields get upper access levels, which means when you access `student.phone`, we will get the field called phone in student, not the one in the Human struct. This feature can be simply seen as field `overload`ing.
+Go use a very simple way to solve it. The outer fields get upper access levels, which means when you access `student.phone`, we will get the field called phone in student, not the one in the Human struct. This feature can be simply seen as field `overloading`.
 ```Go
 package main
 


### PR DESCRIPTION
Fix Markdown error in displaying in en/02.3 & 02.4
I change from
```
The dot operator means you can omit the package name when you call functions inside of that package. Now `fmt.Printf("Hello world")` becomes to `Printf("Hello world")`.
```
 to 
The dot operator means you can omit the package name when you call functions inside of that package. Now `fmt.Printf("Hello world")` becomes to `Printf("Hello world")`.

and fix a error
from `overload`ing. to `overloading`.