### PR TITLE
update godoc -> go doc for cli output

### DIFF
--- a/en/01.3.md
+++ b/en/01.3.md
@@ -79,11 +79,11 @@ This command loads all files whose name include `*_test.go` and generates test f
 
 It tests all your test files by default. Use command `go help testflag` for more details.
 
-## godoc
+## go doc & godoc
 
 Many people say that we don't need any third-party documentation for programming in Go (actually I've made a [CHM](https://github.com/astaxie/godoc) already). Go has a powerful tool to manage documentation natively.
 
-So how do we look up package information in documentation? For instance, if you want to get more details about the `builtin` package, use the `godoc builtin` command. Similarly, use the `godoc net/http` command to look up the `http` package documentation. If you want to see more details about specific functions, use the `godoc fmt Printf` and `godoc -src fmt Printf` commands to view the source code.
+So how do we look up package information in documentation? For instance, if you want to get more details about the `builtin` package, use the `go doc builtin` command. Similarly, use the `go doc net/http` command to look up the `http` package documentation. If you want to see more details about specific functions, use the `go doc fmt.Printf` and `go doc -src fmt.Printf` commands to view the source code.
 
 Execute the `godoc -http=:8080` command, then open `127.0.0.1:8080` in your browser. You should see a localized golang.org. It can not only show the standard packages' information, but also packages in your `$GOPATH/pkg`. It's great for people who are suffering from the Great Firewall of China.
 


### PR DESCRIPTION
I'm new to Go, but far as I can tell this is the correct way to do this now; at least e.g. `godoc builtin` just returns the godoc help info.