### PR TITLE
Update 05.5.md

### DIFF
--- a/zh/05.5.md
+++ b/zh/05.5.md
@@ -42,7 +42,7 @@ import (
 
 func init() {
 	//注册驱动
-	orm.RegisterDriver("mysql", orm.DR_MySQL)
+	orm.RegisterDriver("mysql", orm.DRMySQL)
 	//设置默认数据库
 	orm.RegisterDataBase("default", "mysql", "root:root@/my_db?charset=utf8", 30)
 	//注册定义的model


### PR DESCRIPTION
在学习中发现最新版的beego常量是驼峰写法，以前是下划线，发现很多处都改了，刚开始只注意到mysql部分的