### PR TITLE
Use regexp.Compile where possible

### DIFF
--- a/en/build.go
+++ b/en/build.go
@@ -38,10 +38,18 @@ func (self *Visitor) md2html(arg map[string]string) error {
 
 		input_byte, _ := ioutil.ReadAll(file)
 		input := string(input_byte)
-		input = regexp.MustCompile(`\[(.*?)\]\(<?(.*?)\.md>?\)`).ReplaceAllString(input, "[$1](<$2.html>)")
+		reg, err := regexp.Compile(`\[(.*?)\]\(<?(.*?)\.md>?\)`)
+		if err != nil {
+			fmt.Printf(os.Stderr, "Regex failed to compile %v \n", err)
+		}
+		input = reg.ReplaceAllString(input, "[$1](<$2.html>)")
 
 		if f.Name() == "README.md" {
-			input = regexp.MustCompile(`https:\/\/github\.com\/astaxie\/build-web-application-with-golang\/blob\/master\/`).ReplaceAllString(input, "")
+			reg, err = regexp.Compile(`https:\/\/github\.com\/astaxie\/build-web-application-with-golang\/blob\/master\/`)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
+			}
+			input = reg.ReplaceAllString(input, "")
 		}
 
 		// 以#开头的行，在#后增加空格

--- a/en/build.go
+++ b/en/build.go
@@ -11,6 +11,13 @@ import (
 	"github.com/fairlyblank/md2min"
 )
 
+var reg1 = regexp.MustCompile(`\[(.*?)\]\(<?(.*?)\.md>?\)`)
+var reg2 = regexp.MustCompile(`https:\/\/github\.com\/astaxie\/build-web-application-with-golang\/blob\/master\/`)
+var re_header = regexp.MustCompile(`(?m)^#.+$`)
+var re_sub = regexp.MustCompile(`^(#+)\s*(.+)$`)
+var re_footer1 = regexp.MustCompile(`(?m)^#{2,} links.*?\n(.+\n)*`)
+var re_footer2 = regexp.MustCompile(`png\?raw=true`)
+
 // 定义一个访问者结构体
 type Visitor struct{}
 
@@ -38,18 +45,10 @@ func (self *Visitor) md2html(arg map[string]string) error {
 
 		input_byte, _ := ioutil.ReadAll(file)
 		input := string(input_byte)
-		reg, err := regexp.Compile(`\[(.*?)\]\(<?(.*?)\.md>?\)`)
-		if err != nil {
-			fmt.Printf(os.Stderr, "Regex failed to compile %v \n", err)
-		}
-		input = reg.ReplaceAllString(input, "[$1](<$2.html>)")
+		input = reg1.ReplaceAllString(input, "[$1](<$2.html>)")
 
 		if f.Name() == "README.md" {
-			reg, err = regexp.Compile(`https:\/\/github\.com\/astaxie\/build-web-application-with-golang\/blob\/master\/`)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
-			}
-			input = reg.ReplaceAllString(input, "")
+			input = reg2.ReplaceAllString(input, "")
 		}
 
 		// 以#开头的行，在#后增加空格
@@ -83,8 +82,6 @@ func (self *Visitor) md2html(arg map[string]string) error {
 }
 
 func FixHeader(input string) string {
-	re_header := regexp.MustCompile(`(?m)^#.+$`)
-	re_sub := regexp.MustCompile(`^(#+)\s*(.+)$`)
 	fixer := func(header string) string {
 		s := re_sub.FindStringSubmatch(header)
 		return s[1] + " " + s[2]
@@ -93,13 +90,11 @@ func FixHeader(input string) string {
 }
 
 func RemoveFooterLink(input string) string {
-	re_footer := regexp.MustCompile(`(?m)^#{2,} links.*?\n(.+\n)*`)
-	return re_footer.ReplaceAllString(input, "")
+	return re_footer1.ReplaceAllString(input, "")
 }
 
 func RemoveImageLinkSuffix(input string) string {
-	re_footer := regexp.MustCompile(`png\?raw=true`)
-	return re_footer.ReplaceAllString(input, "png")
+	return re_footer2.ReplaceAllString(input, "png")
 }
 
 func main() {

--- a/ja/build.go
+++ b/ja/build.go
@@ -38,10 +38,18 @@ func (self *Visitor) md2html(arg map[string]string) error {
 
 		input_byte, _ := ioutil.ReadAll(file)
 		input := string(input_byte)
-		input = regexp.MustCompile(`\[(.*?)\]\(<?(.*?)\.md>?\)`).ReplaceAllString(input, "[$1](<$2.html>)")
+		reg, err := regexp.Compile(`\[(.*?)\]\(<?(.*?)\.md>?\)`)
+		if err != nil {
+			fmt.Printf(os.Stderr, "Regex failed to compile %v \n", err)
+		}
+		input = reg.ReplaceAllString(input, "[$1](<$2.html>)")
 
 		if f.Name() == "README.md" {
-			input = regexp.MustCompile(`https:\/\/github\.com\/astaxie\/build-web-application-with-golang\/blob\/master\/`).ReplaceAllString(input, "")
+			reg, err = regexp.Compile(`https:\/\/github\.com\/astaxie\/build-web-application-with-golang\/blob\/master\/`)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
+			}
+			input = reg.ReplaceAllString(input, "")
 		}
 
 		// 以#开头的行，在#后增加空格

--- a/ja/build.go
+++ b/ja/build.go
@@ -11,6 +11,13 @@ import (
 	"github.com/fairlyblank/md2min"
 )
 
+var reg1 = regexp.MustCompile(`\[(.*?)\]\(<?(.*?)\.md>?\)`)
+var reg2 = regexp.MustCompile(`https:\/\/github\.com\/astaxie\/build-web-application-with-golang\/blob\/master\/`)
+var re_header = regexp.MustCompile(`(?m)^#.+$`)
+var re_sub = regexp.MustCompile(`^(#+)\s*(.+)$`)
+var re_footer1 = regexp.MustCompile(`(?m)^#{2,} links.*?\n(.+\n)*`)
+var re_footer2 = regexp.MustCompile(`png\?raw=true`)
+
 // 定义一个访问者结构体
 type Visitor struct{}
 
@@ -38,18 +45,10 @@ func (self *Visitor) md2html(arg map[string]string) error {
 
 		input_byte, _ := ioutil.ReadAll(file)
 		input := string(input_byte)
-		reg, err := regexp.Compile(`\[(.*?)\]\(<?(.*?)\.md>?\)`)
-		if err != nil {
-			fmt.Printf(os.Stderr, "Regex failed to compile %v \n", err)
-		}
-		input = reg.ReplaceAllString(input, "[$1](<$2.html>)")
+		input = reg1.ReplaceAllString(input, "[$1](<$2.html>)")
 
 		if f.Name() == "README.md" {
-			reg, err = regexp.Compile(`https:\/\/github\.com\/astaxie\/build-web-application-with-golang\/blob\/master\/`)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
-			}
-			input = reg.ReplaceAllString(input, "")
+			input = reg2.ReplaceAllString(input, "")
 		}
 
 		// 以#开头的行，在#后增加空格
@@ -83,8 +82,6 @@ func (self *Visitor) md2html(arg map[string]string) error {
 }
 
 func FixHeader(input string) string {
-	re_header := regexp.MustCompile(`(?m)^#.+$`)
-	re_sub := regexp.MustCompile(`^(#+)\s*(.+)$`)
 	fixer := func(header string) string {
 		s := re_sub.FindStringSubmatch(header)
 		return s[1] + " " + s[2]
@@ -93,13 +90,11 @@ func FixHeader(input string) string {
 }
 
 func RemoveFooterLink(input string) string {
-	re_footer := regexp.MustCompile(`(?m)^#{2,} links.*?\n(.+\n)*`)
-	return re_footer.ReplaceAllString(input, "")
+	return re_footer1.ReplaceAllString(input, "")
 }
 
 func RemoveImageLinkSuffix(input string) string {
-	re_footer := regexp.MustCompile(`png\?raw=true`)
-	return re_footer.ReplaceAllString(input, "png")
+	return re_footer2.ReplaceAllString(input, "png")
 }
 
 func main() {

--- a/th/build.go
+++ b/th/build.go
@@ -11,6 +11,13 @@ import (
 	"github.com/fairlyblank/md2min"
 )
 
+var reg1 = regexp.MustCompile(`\[(.*?)\]\(<?(.*?)\.md>?\)`)
+var reg2 = regexp.MustCompile(`https:\/\/github\.com\/astaxie\/build-web-application-with-golang\/blob\/master\/`)
+var re_header = regexp.MustCompile(`(?m)^#.+$`)
+var re_sub = regexp.MustCompile(`^(#+)\s*(.+)$`)
+var re_footer1 = regexp.MustCompile(`(?m)^#{2,} links.*?\n(.+\n)*`)
+var re_footer2 = regexp.MustCompile(`png\?raw=true`)
+
 // 定义一个访问者结构体
 type Visitor struct{}
 
@@ -38,18 +45,10 @@ func (self *Visitor) md2html(arg map[string]string) error {
 
 		input_byte, _ := ioutil.ReadAll(file)
 		input := string(input_byte)
-		reg, err := regexp.Compile(`\[(.*?)\]\(<?(.*?)\.md>?\)`)
-		if err != nil {
-			fmt.Printf(os.Stderr, "Regex failed to compile %v \n", err)
-		}
-		input = reg.ReplaceAllString(input, "[$1](<$2.html>)")
+		input = reg1.ReplaceAllString(input, "[$1](<$2.html>)")
 
 		if f.Name() == "README.md" {
-			reg, err = regexp.Compile(`https:\/\/github\.com\/astaxie\/build-web-application-with-golang\/blob\/master\/`)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
-			}
-			input = reg.ReplaceAllString(input, "")
+			input = reg2.ReplaceAllString(input, "")
 		}
 
 		// 以#开头的行，在#后增加空格
@@ -83,14 +82,6 @@ func (self *Visitor) md2html(arg map[string]string) error {
 }
 
 func FixHeader(input string) string {
-	re_header, err := regexp.Compile(`(?m)^#.+$`)
-	if err != nil{
-		fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
-	}
-	re_sub, err := regexp.Compile(`^(#+)\s*(.+)$`)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
-	}
 	fixer := func(header string) string {
 		s := re_sub.FindStringSubmatch(header)
 		return s[1] + " " + s[2]
@@ -99,19 +90,11 @@ func FixHeader(input string) string {
 }
 
 func RemoveFooterLink(input string) string {
-	re_footer, err := regexp.Compile(`(?m)^#{2,} links.*?\n(.+\n)*`)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
-	}
-	return re_footer.ReplaceAllString(input, "")
+	return re_footer1.ReplaceAllString(input, "")
 }
 
 func RemoveImageLinkSuffix(input string) string {
-	re_footer, err := regexp.Compile(`png\?raw=true`)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
-	}
-	return re_footer.ReplaceAllString(input, "png")
+	return re_footer2.ReplaceAllString(input, "png")
 }
 
 func main() {

--- a/th/build.go
+++ b/th/build.go
@@ -38,10 +38,18 @@ func (self *Visitor) md2html(arg map[string]string) error {
 
 		input_byte, _ := ioutil.ReadAll(file)
 		input := string(input_byte)
-		input = regexp.MustCompile(`\[(.*?)\]\(<?(.*?)\.md>?\)`).ReplaceAllString(input, "[$1](<$2.html>)")
+		reg, err := regexp.Compile(`\[(.*?)\]\(<?(.*?)\.md>?\)`)
+		if err != nil {
+			fmt.Printf(os.Stderr, "Regex failed to compile %v \n", err)
+		}
+		input = reg.ReplaceAllString(input, "[$1](<$2.html>)")
 
 		if f.Name() == "README.md" {
-			input = regexp.MustCompile(`https:\/\/github\.com\/astaxie\/build-web-application-with-golang\/blob\/master\/`).ReplaceAllString(input, "")
+			reg, err = regexp.Compile(`https:\/\/github\.com\/astaxie\/build-web-application-with-golang\/blob\/master\/`)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
+			}
+			input = reg.ReplaceAllString(input, "")
 		}
 
 		// 以#开头的行，在#后增加空格
@@ -75,8 +83,14 @@ func (self *Visitor) md2html(arg map[string]string) error {
 }
 
 func FixHeader(input string) string {
-	re_header := regexp.MustCompile(`(?m)^#.+$`)
-	re_sub := regexp.MustCompile(`^(#+)\s*(.+)$`)
+	re_header, err := regexp.Compile(`(?m)^#.+$`)
+	if err != nil{
+		fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
+	}
+	re_sub, err := regexp.Compile(`^(#+)\s*(.+)$`)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
+	}
 	fixer := func(header string) string {
 		s := re_sub.FindStringSubmatch(header)
 		return s[1] + " " + s[2]
@@ -85,12 +99,18 @@ func FixHeader(input string) string {
 }
 
 func RemoveFooterLink(input string) string {
-	re_footer := regexp.MustCompile(`(?m)^#{2,} links.*?\n(.+\n)*`)
+	re_footer, err := regexp.Compile(`(?m)^#{2,} links.*?\n(.+\n)*`)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
+	}
 	return re_footer.ReplaceAllString(input, "")
 }
 
 func RemoveImageLinkSuffix(input string) string {
-	re_footer := regexp.MustCompile(`png\?raw=true`)
+	re_footer, err := regexp.Compile(`png\?raw=true`)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
+	}
 	return re_footer.ReplaceAllString(input, "png")
 }
 

--- a/zh-tw/build.go
+++ b/zh-tw/build.go
@@ -40,10 +40,18 @@ func (self *Visitor) md2html(arg map[string]string) error {
 
 		input_byte, _ := ioutil.ReadAll(file)
 		input := string(input_byte)
-		input = regexp.MustCompile(`\[(.*?)\]\(<?(.*?)\.md>?\)`).ReplaceAllString(input, "[$1](<$2.html>)")
+		reg, err := regexp.Compile(`\[(.*?)\]\(<?(.*?)\.md>?\)`)
+		if err != nil {
+			fmt.Printf(os.Stderr, "Regex failed to compile %v \n", err)
+		}
+		input = reg.ReplaceAllString(input, "[$1](<$2.html>)")
 
 		if f.Name() == "README.md" {
-			input = regexp.MustCompile(`https:\/\/github\.com\/astaxie\/build-web-application-with-golang\/blob\/master\/`).ReplaceAllString(input, "")
+			reg, err = regexp.Compile(`https:\/\/github\.com\/astaxie\/build-web-application-with-golang\/blob\/master\/`)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
+			}
+			input = reg.ReplaceAllString(input, "")
 		}
 
 		// 以#开头的行，在#后增加空格
@@ -84,8 +92,14 @@ func (self *Visitor) md2html(arg map[string]string) error {
 }
 
 func FixHeader(input string) string {
-	re_header := regexp.MustCompile(`(?m)^#.+$`)
-	re_sub := regexp.MustCompile(`^(#+)\s*(.+)$`)
+	re_header, err := regexp.Compile(`(?m)^#.+$`)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
+	}
+	re_sub, err := regexp.Compile(`^(#+)\s*(.+)$`)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
+	}
 	fixer := func(header string) string {
 		s := re_sub.FindStringSubmatch(header)
 		return s[1] + " " + s[2]
@@ -94,12 +108,18 @@ func FixHeader(input string) string {
 }
 
 func RemoveFooterLink(input string) string {
-	re_footer := regexp.MustCompile(`(?m)^#{2,} links.*?\n(.+\n)*`)
+	re_footer, err := regexp.Compile(`(?m)^#{2,} links.*?\n(.+\n)*`)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
+	}
 	return re_footer.ReplaceAllString(input, "")
 }
 
 func RemoveImageLinkSuffix(input string) string {
-	re_footer := regexp.MustCompile(`png\?raw=true`)
+	re_footer, err := regexp.Compile(`png\?raw=true`)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Regex failed to compile", err)
+	}
 	return re_footer.ReplaceAllString(input, "png")
 }
 

--- a/zh-tw/build.go
+++ b/zh-tw/build.go
@@ -11,6 +11,13 @@ import (
 	"strings"
 )
 
+var reg1 = regexp.MustCompile(`\[(.*?)\]\(<?(.*?)\.md>?\)`)
+var reg2 = regexp.MustCompile(`https:\/\/github\.com\/astaxie\/build-web-application-with-golang\/blob\/master\/`)
+var re_header = regexp.MustCompile(`(?m)^#.+$`)
+var re_sub = regexp.MustCompile(`^(#+)\s*(.+)$`)
+var re_footer1 = regexp.MustCompile(`(?m)^#{2,} links.*?\n(.+\n)*`)
+var re_footer2 = regexp.MustCompile(`png\?raw=true`)
+
 // 定义一个访问者结构体
 type Visitor struct{}
 
@@ -40,18 +47,10 @@ func (self *Visitor) md2html(arg map[string]string) error {
 
 		input_byte, _ := ioutil.ReadAll(file)
 		input := string(input_byte)
-		reg, err := regexp.Compile(`\[(.*?)\]\(<?(.*?)\.md>?\)`)
-		if err != nil {
-			fmt.Printf(os.Stderr, "Regex failed to compile %v \n", err)
-		}
-		input = reg.ReplaceAllString(input, "[$1](<$2.html>)")
+		input = reg1.ReplaceAllString(input, "[$1](<$2.html>)")
 
 		if f.Name() == "README.md" {
-			reg, err = regexp.Compile(`https:\/\/github\.com\/astaxie\/build-web-application-with-golang\/blob\/master\/`)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
-			}
-			input = reg.ReplaceAllString(input, "")
+			input = reg2.ReplaceAllString(input, "")
 		}
 
 		// 以#开头的行，在#后增加空格
@@ -92,14 +91,6 @@ func (self *Visitor) md2html(arg map[string]string) error {
 }
 
 func FixHeader(input string) string {
-	re_header, err := regexp.Compile(`(?m)^#.+$`)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
-	}
-	re_sub, err := regexp.Compile(`^(#+)\s*(.+)$`)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
-	}
 	fixer := func(header string) string {
 		s := re_sub.FindStringSubmatch(header)
 		return s[1] + " " + s[2]
@@ -108,18 +99,10 @@ func FixHeader(input string) string {
 }
 
 func RemoveFooterLink(input string) string {
-	re_footer, err := regexp.Compile(`(?m)^#{2,} links.*?\n(.+\n)*`)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
-	}
-	return re_footer.ReplaceAllString(input, "")
+	return re_footer1.ReplaceAllString(input, "")
 }
 
 func RemoveImageLinkSuffix(input string) string {
-	re_footer, err := regexp.Compile(`png\?raw=true`)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Regex failed to compile", err)
-	}
 	return re_footer.ReplaceAllString(input, "png")
 }
 

--- a/zh-tw/build_new.go
+++ b/zh-tw/build_new.go
@@ -11,6 +11,13 @@ import (
 	"strings"
 )
 
+var reg1 = regexp.MustCompile(`\[(.*?)\]\(<?(.*?)\.md>?\)`)
+var reg2 = regexp.MustCompile(`https:\/\/github\.com\/astaxie\/build-web-application-with-golang\/blob\/master\/`)
+var re_header = regexp.MustCompile(`(?m)^#.+$`)
+var re_sub = regexp.MustCompile(`^(#+)\s*(.+)$`)
+var re_footer1 = regexp.MustCompile(`(?m)^#{2,} links.*?\n(.+\n)*`)
+var re_footer2 = regexp.MustCompile(`png\?raw=true`)
+
 // 开发者 GitHub token
 const token = ""
 
@@ -43,18 +50,10 @@ func (self *Visitor) md2html(arg map[string]string) error {
 
 		input_byte, _ := ioutil.ReadAll(file)
 		input := string(input_byte)
-		reg, err := regexp.Compile(`\[(.*?)\]\(<?(.*?)\.md>?\)`)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
-		}
-		input = reg.ReplaceAllString(input, "[$1](<$2.html>)")
+		input = reg1.ReplaceAllString(input, "[$1](<$2.html>)")
 
 		if f.Name() == "README.md" {
-			reg, err = regexp.Compile(`https:\/\/github\.com\/astaxie\/build-web-application-with-golang\/blob\/master\/`)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
-			}
-			input = reg.ReplaceAllString(input, "")
+			input = reg2.ReplaceAllString(input, "")
 		}
 
 		// 以#开头的行，在#后增加空格
@@ -112,14 +111,6 @@ func (self *Visitor) md2html(arg map[string]string) error {
 }
 
 func FixHeader(input string) string {
-	re_header, err := regexp.Compile(`(?m)^#.+$`)
-	if err != nil{
-		fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
-	}
-	re_sub, err := regexp.Compile(`^(#+)\s*(.+)$`)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
-	}
 	fixer := func(header string) string {
 		s := re_sub.FindStringSubmatch(header)
 		return s[1] + " " + s[2]
@@ -128,19 +119,11 @@ func FixHeader(input string) string {
 }
 
 func RemoveFooterLink(input string) string {
-	re_footer, err := regexp.Compile(`(?m)^#{2,} links.*?\n(.+\n)*`)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
-	}
-	return re_footer.ReplaceAllString(input, "")
+	return re_footer1.ReplaceAllString(input, "")
 }
 
 func RemoveImageLinkSuffix(input string) string {
-	re_footer, err := regexp.Compile(`png\?raw=true`)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
-	}
-	return re_footer.ReplaceAllString(input, "png")
+	return re_footer2.ReplaceAllString(input, "png")
 }
 
 func main() {

--- a/zh-tw/build_new.go
+++ b/zh-tw/build_new.go
@@ -43,10 +43,18 @@ func (self *Visitor) md2html(arg map[string]string) error {
 
 		input_byte, _ := ioutil.ReadAll(file)
 		input := string(input_byte)
-		input = regexp.MustCompile(`\[(.*?)\]\(<?(.*?)\.md>?\)`).ReplaceAllString(input, "[$1](<$2.html>)")
+		reg, err := regexp.Compile(`\[(.*?)\]\(<?(.*?)\.md>?\)`)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
+		}
+		input = reg.ReplaceAllString(input, "[$1](<$2.html>)")
 
 		if f.Name() == "README.md" {
-			input = regexp.MustCompile(`https:\/\/github\.com\/astaxie\/build-web-application-with-golang\/blob\/master\/`).ReplaceAllString(input, "")
+			reg, err = regexp.Compile(`https:\/\/github\.com\/astaxie\/build-web-application-with-golang\/blob\/master\/`)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
+			}
+			input = reg.ReplaceAllString(input, "")
 		}
 
 		// 以#开头的行，在#后增加空格
@@ -104,8 +112,14 @@ func (self *Visitor) md2html(arg map[string]string) error {
 }
 
 func FixHeader(input string) string {
-	re_header := regexp.MustCompile(`(?m)^#.+$`)
-	re_sub := regexp.MustCompile(`^(#+)\s*(.+)$`)
+	re_header, err := regexp.Compile(`(?m)^#.+$`)
+	if err != nil{
+		fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
+	}
+	re_sub, err := regexp.Compile(`^(#+)\s*(.+)$`)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
+	}
 	fixer := func(header string) string {
 		s := re_sub.FindStringSubmatch(header)
 		return s[1] + " " + s[2]
@@ -114,12 +128,18 @@ func FixHeader(input string) string {
 }
 
 func RemoveFooterLink(input string) string {
-	re_footer := regexp.MustCompile(`(?m)^#{2,} links.*?\n(.+\n)*`)
+	re_footer, err := regexp.Compile(`(?m)^#{2,} links.*?\n(.+\n)*`)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
+	}
 	return re_footer.ReplaceAllString(input, "")
 }
 
 func RemoveImageLinkSuffix(input string) string {
-	re_footer := regexp.MustCompile(`png\?raw=true`)
+	re_footer, err := regexp.Compile(`png\?raw=true`)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
+	}
 	return re_footer.ReplaceAllString(input, "png")
 }
 

--- a/zh/build.go
+++ b/zh/build.go
@@ -11,6 +11,13 @@ import (
 	"strings"
 )
 
+var reg1 = regexp.MustCompile(`\[(.*?)\]\(<?(.*?)\.md>?\)`)
+var reg2 = regexp.MustCompile(`https:\/\/github\.com\/astaxie\/build-web-application-with-golang\/blob\/master\/`)
+var re_header = regexp.MustCompile(`(?m)^#.+$`)
+var re_sub = regexp.MustCompile(`^(#+)\s*(.+)$`)
+var re_footer1 = regexp.MustCompile(`(?m)^#{2,} links.*?\n(.+\n)*`)
+var re_footer2 = regexp.MustCompile(`png\?raw=true`)
+
 // 定义一个访问者结构体
 type Visitor struct{}
 
@@ -40,18 +47,10 @@ func (self *Visitor) md2html(arg map[string]string) error {
 
 		input_byte, _ := ioutil.ReadAll(file)
 		input := string(input_byte)
-		reg, err := regexp.Compile(`\[(.*?)\]\(<?(.*?)\.md>?\)`)
-		if err != nil {
-			fmt.Printf(os.Stderr, "Regex failed to compile %v \n", err)
-		}
-		input = reg.ReplaceAllString(input, "[$1](<$2.html>)")
+		input = reg1.ReplaceAllString(input, "[$1](<$2.html>)")
 
 		if f.Name() == "README.md" {
-			reg, err = regexp.Compile(`https:\/\/github\.com\/astaxie\/build-web-application-with-golang\/blob\/master\/`)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
-			}
-			input = reg.ReplaceAllString(input, "")
+			input = reg2.ReplaceAllString(input, "")
 		}
 
 
@@ -93,14 +92,6 @@ func (self *Visitor) md2html(arg map[string]string) error {
 }
 
 func FixHeader(input string) string {
-	re_header, err := regexp.Compile(`(?m)^#.+$`)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
-	}
-	re_sub, err := regexp.Compile(`^(#+)\s*(.+)$`)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
-	}
 	fixer := func(header string) string {
 		s := re_sub.FindStringSubmatch(header)
 		return s[1] + " " + s[2]
@@ -109,19 +100,11 @@ func FixHeader(input string) string {
 }
 
 func RemoveFooterLink(input string) string {
-	re_footer, err := regexp.Compile(`(?m)^#{2,} links.*?\n(.+\n)*`)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
-	}
-	return re_footer.ReplaceAllString(input, "")
+	return re_footer1.ReplaceAllString(input, "")
 }
 
 func RemoveImageLinkSuffix(input string) string {
-	re_footer, err := regexp.Compile(`png\?raw=true`)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
-	}
-	return re_footer.ReplaceAllString(input, "png")
+	return re_footer2.ReplaceAllString(input, "png")
 }
 
 func main() {

--- a/zh/build.go
+++ b/zh/build.go
@@ -40,11 +40,20 @@ func (self *Visitor) md2html(arg map[string]string) error {
 
 		input_byte, _ := ioutil.ReadAll(file)
 		input := string(input_byte)
-		input = regexp.MustCompile(`\[(.*?)\]\(<?(.*?)\.md>?\)`).ReplaceAllString(input, "[$1](<$2.html>)")
+		reg, err := regexp.Compile(`\[(.*?)\]\(<?(.*?)\.md>?\)`)
+		if err != nil {
+			fmt.Printf(os.Stderr, "Regex failed to compile %v \n", err)
+		}
+		input = reg.ReplaceAllString(input, "[$1](<$2.html>)")
 
 		if f.Name() == "README.md" {
-			input = regexp.MustCompile(`https:\/\/github\.com\/astaxie\/build-web-application-with-golang\/blob\/master\/`).ReplaceAllString(input, "")
+			reg, err = regexp.Compile(`https:\/\/github\.com\/astaxie\/build-web-application-with-golang\/blob\/master\/`)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
+			}
+			input = reg.ReplaceAllString(input, "")
 		}
+
 
 		// 以#开头的行，在#后增加空格
 		// 以#开头的行, 删除多余的空格
@@ -84,8 +93,14 @@ func (self *Visitor) md2html(arg map[string]string) error {
 }
 
 func FixHeader(input string) string {
-	re_header := regexp.MustCompile(`(?m)^#.+$`)
-	re_sub := regexp.MustCompile(`^(#+)\s*(.+)$`)
+	re_header, err := regexp.Compile(`(?m)^#.+$`)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
+	}
+	re_sub, err := regexp.Compile(`^(#+)\s*(.+)$`)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
+	}
 	fixer := func(header string) string {
 		s := re_sub.FindStringSubmatch(header)
 		return s[1] + " " + s[2]
@@ -94,12 +109,18 @@ func FixHeader(input string) string {
 }
 
 func RemoveFooterLink(input string) string {
-	re_footer := regexp.MustCompile(`(?m)^#{2,} links.*?\n(.+\n)*`)
+	re_footer, err := regexp.Compile(`(?m)^#{2,} links.*?\n(.+\n)*`)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
+	}
 	return re_footer.ReplaceAllString(input, "")
 }
 
 func RemoveImageLinkSuffix(input string) string {
-	re_footer := regexp.MustCompile(`png\?raw=true`)
+	re_footer, err := regexp.Compile(`png\?raw=true`)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
+	}
 	return re_footer.ReplaceAllString(input, "png")
 }
 

--- a/zh/build_new.go
+++ b/zh/build_new.go
@@ -11,6 +11,13 @@ import (
 	"strings"
 )
 
+var reg1 = regexp.MustCompile(`\[(.*?)\]\(<?(.*?)\.md>?\)`)
+var reg2 = regexp.MustCompile(`https:\/\/github\.com\/astaxie\/build-web-application-with-golang\/blob\/master\/`)
+var re_header = regexp.MustCompile(`(?m)^#.+$`)
+var re_sub = regexp.MustCompile(`^(#+)\s*(.+)$`)
+var re_footer1 = regexp.MustCompile(`(?m)^#{2,} links.*?\n(.+\n)*`)
+var re_footer2 = regexp.MustCompile(`png\?raw=true`)
+
 // 开发者 GitHub token
 const token = ""
 
@@ -43,25 +50,15 @@ func (self *Visitor) md2html(arg map[string]string) error {
 
 		input_byte, _ := ioutil.ReadAll(file)
 		input := string(input_byte)
-		reg, err := regexp.Compile(`\[(.*?)\]\(<?(.*?)\.md>?\)`)
-		if err != nil {
-			fmt.Printf(os.Stderr, "Regex failed to compile %v \n", err)
-		}
-		input = reg.ReplaceAllString(input, "[$1](<$2.html>)")
+		input = reg1.ReplaceAllString(input, "[$1](<$2.html>)")
 
 		if f.Name() == "README.md" {
-			reg, err = regexp.Compile(`https:\/\/github\.com\/astaxie\/build-web-application-with-golang\/blob\/master\/`)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
-			}
-			input = reg.ReplaceAllString(input, "")
+			input = reg2.ReplaceAllString(input, "")
 		}
 
 		// 以#开头的行，在#后增加空格
 		// 以#开头的行, 删除多余的空格
 		input = FixHeader(input)
-
-		// 删除页面链接
 		input = RemoveFooterLink(input)
 
 		// remove image suffix
@@ -112,14 +109,6 @@ func (self *Visitor) md2html(arg map[string]string) error {
 }
 
 func FixHeader(input string) string {
-	re_header, err := regexp.Compile(`(?m)^#.+$`)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
-	}
-	re_sub, err := regexp.Compile(`^(#+)\s*(.+)$`)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
-	}
 	fixer := func(header string) string {
 		s := re_sub.FindStringSubmatch(header)
 		return s[1] + " " + s[2]
@@ -128,19 +117,11 @@ func FixHeader(input string) string {
 }
 
 func RemoveFooterLink(input string) string {
-	re_footer, err := regexp.Compile(`(?m)^#{2,} links.*?\n(.+\n)*`)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
-	}
-	return re_footer.ReplaceAllString(input, "")
+	return re_footer1.ReplaceAllString(input, "")
 }
 
 func RemoveImageLinkSuffix(input string) string {
-	re_footer, err := regexp.Compile(`png\?raw=true`)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
-	}
-	return re_footer.ReplaceAllString(input, "png")
+	return re_footer2.ReplaceAllString(input, "png")
 }
 
 func main() {

--- a/zh/build_new.go
+++ b/zh/build_new.go
@@ -43,10 +43,18 @@ func (self *Visitor) md2html(arg map[string]string) error {
 
 		input_byte, _ := ioutil.ReadAll(file)
 		input := string(input_byte)
-		input = regexp.MustCompile(`\[(.*?)\]\(<?(.*?)\.md>?\)`).ReplaceAllString(input, "[$1](<$2.html>)")
+		reg, err := regexp.Compile(`\[(.*?)\]\(<?(.*?)\.md>?\)`)
+		if err != nil {
+			fmt.Printf(os.Stderr, "Regex failed to compile %v \n", err)
+		}
+		input = reg.ReplaceAllString(input, "[$1](<$2.html>)")
 
 		if f.Name() == "README.md" {
-			input = regexp.MustCompile(`https:\/\/github\.com\/astaxie\/build-web-application-with-golang\/blob\/master\/`).ReplaceAllString(input, "")
+			reg, err = regexp.Compile(`https:\/\/github\.com\/astaxie\/build-web-application-with-golang\/blob\/master\/`)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
+			}
+			input = reg.ReplaceAllString(input, "")
 		}
 
 		// 以#开头的行，在#后增加空格
@@ -104,8 +112,14 @@ func (self *Visitor) md2html(arg map[string]string) error {
 }
 
 func FixHeader(input string) string {
-	re_header := regexp.MustCompile(`(?m)^#.+$`)
-	re_sub := regexp.MustCompile(`^(#+)\s*(.+)$`)
+	re_header, err := regexp.Compile(`(?m)^#.+$`)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
+	}
+	re_sub, err := regexp.Compile(`^(#+)\s*(.+)$`)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
+	}
 	fixer := func(header string) string {
 		s := re_sub.FindStringSubmatch(header)
 		return s[1] + " " + s[2]
@@ -114,12 +128,18 @@ func FixHeader(input string) string {
 }
 
 func RemoveFooterLink(input string) string {
-	re_footer := regexp.MustCompile(`(?m)^#{2,} links.*?\n(.+\n)*`)
+	re_footer, err := regexp.Compile(`(?m)^#{2,} links.*?\n(.+\n)*`)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
+	}
 	return re_footer.ReplaceAllString(input, "")
 }
 
 func RemoveImageLinkSuffix(input string) string {
-	re_footer := regexp.MustCompile(`png\?raw=true`)
+	re_footer, err := regexp.Compile(`png\?raw=true`)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Regex failed to compile %v \n", err)
+	}
 	return re_footer.ReplaceAllString(input, "png")
 }
 


### PR DESCRIPTION
The [regexp.MustCompile function](https://golang.org/pkg/regexp/#MustCompile) panics if the regex fails to compile and should only be used in globals or init functions. Instead use [regexp.Compile](https://golang.org/pkg/regexp/#Compile) and check `err` is nil.