### PR TITLE
Fix a bug in the sample code

### DIFF
--- a/zh/04.1.md
+++ b/zh/04.1.md
@@ -52,6 +52,7 @@ func login(w http.ResponseWriter, r *http.Request) {
 		log.Println(t.Execute(w, nil))
 	} else {
 		//请求的是登录数据，那么执行登录的逻辑判断
+		r.ParseForm()
 		fmt.Println("username:", r.Form["username"])
 		fmt.Println("password:", r.Form["password"])
 	}


### PR DESCRIPTION
I think it should also add `r.ParseForm()` in the `login` function. Otherwise, we cannot get `r.Form["username"]` or `r.Form["password"]`