### PR TITLE
bugfix

### DIFF
--- a/en/07.6.md
+++ b/en/07.6.md
@@ -148,10 +148,7 @@ func main() {
 	if err != nil {
 		fmt.Println(err)
 	}
-	e, err := strconv.Itoa("1023")
-	if err != nil {
-		fmt.Println(err)
-	}
+	e := strconv.Itoa(1023)
 	fmt.Println(a, b, c, d, e)
 }
 ```


### PR DESCRIPTION
You can see how the previous version was invalid here:
https://play.golang.org/p/IthX3cWv_V7
```
./prog.go:25:9: assignment mismatch: 2 variables but strconv.Itoa returns 1 values
./prog.go:25:25: cannot use "1023" (type untyped string) as type int in argument to strconv.Itoa
```